### PR TITLE
Type and docs highlighting

### DIFF
--- a/lib/ProofObligationView.coffee
+++ b/lib/ProofObligationView.coffee
@@ -1,15 +1,21 @@
 View = require('atom-space-pen-views').View
 utils = require('./utils')
+highlighter = require './utils/highlighter'
 
 class ProofObligationView extends View
   constructor: (params) ->
     @obligation = params.obligation
+    @highlightingInfo = params.highlightingInfo
     super arguments
 
   @content: ->
     @pre class: 'idris-mode inline-block'
 
   initialize: ->
-    @text @obligation
+    if @highlightingInfo?
+      text = highlighter.highlight @obligation, @highlightingInfo
+      @html text
+    else
+      @text @obligation
 
 module.exports = ProofObligationView

--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -130,14 +130,16 @@ class IdrisController
 
   getTypeForWord: =>
     word = @getWordUnderCursor()
-    @model.getType word, (err, type) =>
+    @model.getType word, (err, type, highlightingInfo) =>
       if err
         @statusbar.setStatus 'Idris: ' + err.message
       else
         @messages.show()
         @messages.clear()
         @messages.setTitle 'Idris: Type of <tt>' + word + '</tt>', true
-        @messages.add new ProofObligationView(obligation: type)
+        @messages.add new ProofObligationView
+          obligation: type
+          highlightingInfo: highlightingInfo
 
   doCaseSplit: =>
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -119,14 +119,16 @@ class IdrisController
 
   getDocsForWord: =>
     word = @getWordUnderCursor()
-    @model.docsFor word, (err, type) =>
+    @model.docsFor word, (err, type, highlightingInfo) =>
       if err
         @statusbar.setStatus 'Idris: ' + err.message
       else
         @messages.show()
         @messages.clear()
         @messages.setTitle 'Idris: Type of <tt>' + word + '</tt>', true
-        @messages.add new ProofObligationView(obligation: type)
+        @messages.add new ProofObligationView
+          obligation: type
+          highlightingInfo: highlightingInfo
 
   getTypeForWord: =>
     word = @getWordUnderCursor()

--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -70,7 +70,7 @@ class IdrisModel extends EventEmitter
           ret = params[0]
           if @callbacks[id]
             if ret[0] == ':ok'
-              @callbacks[id] undefined, ret[1]
+              @callbacks[id] undefined, ret.slice(1)...
             else
               @callbacks[id]
                 message: ret[1]

--- a/lib/utils/highlighter.coffee
+++ b/lib/utils/highlighter.coffee
@@ -1,0 +1,37 @@
+highlightInfoListToOb = (list) ->
+  obj = {}
+  for x in list
+    key = x[0].slice(1)
+    value = x[1]
+    obj[key] = value
+  obj
+
+decorToClasses = (decor) ->
+  switch decor
+    when ':type' then 'storage type'
+    else ''
+
+highlightWord = (word, info) ->
+  "<span class=\"#{decorToClasses info.info.decor} idris\">#{word}</span>"
+
+highlight = (code, highlightingInfo) ->
+  highlighted = highlightingInfo
+    .map (i) ->
+      start: i[0]
+      length: i[1]
+      info: highlightInfoListToOb i[2]
+    .filter (i) ->
+      i.info.decor?
+    .reduce (([position, text], info) ->
+      newPosition = info.start + info.length
+      unhighlightedText = code.slice(position, info.start)
+      highlightedWord = highlightWord code.slice(info.start, newPosition), info
+      newText = text + unhighlightedText + highlightedWord
+
+      [newPosition, newText]
+    ), [0, '']
+  [position, text] = highlighted
+  text + code.slice(position)
+
+module.exports =
+  highlight: highlight

--- a/lib/utils/highlighter.coffee
+++ b/lib/utils/highlighter.coffee
@@ -9,6 +9,10 @@ highlightInfoListToOb = (list) ->
 decorToClasses = (decor) ->
   switch decor
     when ':type' then 'storage type'
+    when ':function' then 'entity name function'
+    when ':data' then 'constant'
+    when ':keyword' then 'keyword'
+    when ':bound' then ''
     else ''
 
 highlightWord = (word, info) ->

--- a/spec/highlighter-spec.coffee
+++ b/spec/highlighter-spec.coffee
@@ -1,0 +1,40 @@
+highlighter = require '../lib/utils/highlighter'
+
+describe "The highlighter", ->
+  it "should highlight correctly.", ->
+    code1 = "Prelude.Nat.Nat : Type"
+    info1 =
+      [
+        [
+          0,
+          15,
+          [
+            [":name","Prelude.Nat.Nat"],
+            [":implicit",false],
+            [":decor",":type"],
+            [":doc-overview","Unary natural numbers"],
+            [":type","Type"],
+            [":namespace","Prelude.Nat"]
+          ]
+        ],
+        [
+          18,
+          4,
+          [
+            [":decor",":type"],
+            [":type","Type"],
+            [":doc-overview","The type of types"],
+            [":name","Type"]
+          ]
+        ],
+        [
+          18,
+          4,
+          [
+            [":tt-term","AAAAAAAAAAAHAP//////////"]
+          ]
+        ]
+      ]
+    should1 = '<span class="storage type idris">Prelude.Nat.Nat</span> : <span class="storage type idris">Type</span>'
+
+    expect(highlighter.highlight(code1, info1)).toEqual(should1)


### PR DESCRIPTION
Adds highligting to the type and documentation views

features:

- highlighting comes from the idris compiler
- easy to add to a new view
- testable

Before:
![without-highlighting](https://cloud.githubusercontent.com/assets/471043/7784388/6b1f5d1c-0164-11e5-999e-7217c3d56aa9.PNG)

After:
![with-highlighting](https://cloud.githubusercontent.com/assets/471043/7784389/6ea0f284-0164-11e5-9fab-e7b4c8c44d5c.PNG)
