### PR TITLE
Initial support for semantic highlights

### DIFF
--- a/lib/language-idris.coffee
+++ b/lib/language-idris.coffee
@@ -10,6 +10,9 @@ module.exports =
     pathToIdris:
       type: 'string'
       default: 'idris'
+    semanticHighlighting:
+      type: 'boolean'
+      default: false
 
   activate: ->
     pathToIdris = atom.config.get "language-idris.pathToIdris"

--- a/lib/utils/sourceHighlight.coffee
+++ b/lib/utils/sourceHighlight.coffee
@@ -1,0 +1,36 @@
+fileLocation = (where) ->
+  [[tag1, file], [tag2, startLine, startCol], [tag3, endLine, endCol]] = where
+  if tag1 == ':filename' && tag2 == ':start' && tag3 == ':end'
+    {file: file, start: [startLine - 1, startCol - 1], end: [endLine - 1 , endCol - 1]}
+  else
+    throw ("bad location " + where)
+
+assoc = (key, list) ->
+  try
+    [car, cdr...] = list
+    [k, vs...] = car
+    if k == key
+      vs
+    else
+      assoc key, cdr
+  catch e
+    null
+
+
+decoClass = (props) ->
+  decor = assoc ':decor', props
+  console.log decor
+  decoClass =
+    switch decor[0]
+      when ':function' then ' function'
+      when ':bound'    then ' bound'
+      when ':data'     then ' data'
+      when ':metavar'  then ' metavar'
+      when ':type'     then ' type'
+      else ''
+  console.log decoClass
+  'idris-thing' + decoClass
+
+module.exports =
+  fileLocation: fileLocation
+  decoClass: decoClass

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     {
       "name": "Heather",
       "url": "https://github.com/Heather"
+    },
+    {
+      "name": "David Christiansen",
+      "url": "http://www.davidchristiansen.dk"
     }
   ],
   "consumedServices": {

--- a/styles/idris.atom-text-editor.less
+++ b/styles/idris.atom-text-editor.less
@@ -1,0 +1,25 @@
+.editor .idris-thing .region {
+
+}
+
+.editor .idris-thing.type .region {
+  background-color: #EBFAFF;
+}
+
+.editor .idris-thing.function .region {
+  background-color: #B2F0B2;
+}
+
+.editor .idris-thing.bound .region {
+  background-color: #D9B2D9;
+}
+.editor .idris-thing.metavar .region {
+  border: 1px solid gray !important;
+}
+
+.editor .idris-thing.data .region {
+  background-color: #FF9999;
+}
+
+.editor .idris-thing.module .region {
+}

--- a/styles/idris.atom-text-editor.less~
+++ b/styles/idris.atom-text-editor.less~
@@ -1,0 +1,3 @@
+.HERE .region {
+  color: red;
+}


### PR DESCRIPTION
Semantic source highlighting information from Idris is no longer ignored.

Atom highlights are not wrapped around the text. Instead, they live at a different z-index, which means they can't apply text highlights. This is why the selection doesn't touch text colors. Thus, the semantic highlights are applied to the background only.

Because they are ugly, they are currently disabled by default in the settings. But it's a start that can be built upon.

This is my first CoffeeScript code ever, so sorry if it's doing something wrong.