### PR TITLE
Explicits saves, plus make-case and make-with

### DIFF
--- a/keymaps/language-idris.json
+++ b/keymaps/language-idris.json
@@ -4,6 +4,9 @@
     "ctrl-alt-t": "language-idris:type-of",
     "ctrl-alt-a": "language-idris:add-clause",
     "ctrl-alt-s": "language-idris:proof-search",
-    "ctrl-alt-d": "language-idris:docs-for"
+    "ctrl-alt-d": "language-idris:docs-for",
+    "ctrl-alt-w": "language-idris:make-with",
+    "ctrl-alt-r": "language-idris:typecheck",
+    "ctrl-alt-m": "language-idris:make-case"
   }
 }

--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -13,6 +13,8 @@ class IdrisController
     'language-idris:docs-for': @runCommand @getDocsForWord
     'language-idris:case-split': @runCommand @doCaseSplit
     'language-idris:add-clause': @runCommand @doAddClause
+    'language-idris:make-with': @runCommand @doMakeWith
+    'language-idris:make-case': @runCommand @doMakeCase
     'language-idris:holes': @runCommand @showHoles
     'language-idris:proof-search': @runCommand @doProofSearch
     'language-idris:typecheck': @runCommand @typecheckFile
@@ -135,6 +137,55 @@ class IdrisController
       .load uri
       .filter ({responseType}) -> responseType == 'return'
       .flatMap => @model.addClause line + 1, word
+      .subscribe successHandler, @displayErrors
+
+  doMakeWith: ({target}) =>
+    editor = target.model
+    editor.save()
+    uri = editor.getURI()
+    line = editor.getLastCursor().getBufferRow()
+    editor.moveToBeginningOfLine()
+    word = @getWordUnderCursor target
+
+    successHandler = ({responseType, msg}) ->
+      [clause] = msg
+      editor.transact ->
+        # Delete old line, insert the new with block
+        editor.deleteLine()
+        editor.insertText clause
+        # And move the cursor to the beginning of
+        # the new line
+        editor.moveToBeginningOfLine()
+        editor.moveUp()
+
+    @model
+      .load uri
+      .filter ({responseType}) -> responseType == 'return'
+      .flatMap => @model.makeWith line + 1, word
+      .subscribe successHandler, @displayErrors
+
+  doMakeCase: ({target}) =>
+    editor = target.model
+    editor.save()
+    uri = editor.getURI()
+    line = editor.getLastCursor().getBufferRow()
+    word = @getWordUnderCursor target
+
+    successHandler = ({responseType, msg}) ->
+      [clause] = msg
+      editor.transact ->
+        # Delete old line, insert the new case block
+        editor.deleteLine()
+        editor.insertText clause
+        # And move the cursor to the beginning of
+        # the new line
+        editor.moveToBeginningOfLine()
+        editor.moveUp()
+
+    @model
+      .load uri
+      .filter ({responseType}) -> responseType == 'return'
+      .flatMap => @model.makeCase line + 1, word
       .subscribe successHandler, @displayErrors
 
   showHoles: ({target}) =>

--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -82,6 +82,7 @@ class IdrisController
       .subscribe successHandler, @displayErrors
 
   getTypeForWord: ({target}) =>
+    target.model.save()
     word = @getWordUnderCursor target
 
     successHandler = ({responseType, msg}) =>
@@ -101,6 +102,7 @@ class IdrisController
 
   doCaseSplit: ({target}) =>
     editor = target.model
+    editor.save()
     uri = editor.getURI()
     cursor = editor.getLastCursor()
     line = cursor.getBufferRow()
@@ -119,6 +121,7 @@ class IdrisController
 
   doAddClause: ({target}) =>
     editor = target.model
+    editor.save()
     uri = editor.getURI()
     line = editor.getLastCursor().getBufferRow()
     word = @getWordUnderCursor target
@@ -204,6 +207,7 @@ class IdrisController
 
   doProofSearch: ({target}) =>
     editor = target.model
+    editor.save()
     uri = editor.getURI()
     line = editor.getLastCursor().getBufferRow()
     word = @getWordUnderCursor target

--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -70,6 +70,12 @@ class IdrisModel
   caseSplit: (line, word) ->
     @prepareCommand [':case-split', line, word]
 
+  makeWith: (line, word) ->
+    @prepareCommand [':make-with', line, word]
+
+  makeCase: (line, word) ->
+    @prepareCommand [':make-case', line, word]
+
   addClause: (line, word) ->
     @prepareCommand [':add-clause', line, word]
 


### PR DESCRIPTION
I've added a couple of the missing interactive features (adding case blocks and with clauses).

This also adds explicit saves to each command, because without them, the buffer contents and what Idris sees are inconsistent.

As may be obvious, I don't actually know what I'm doing with atom extensions, since I'm very new here. So hopefully I haven't done this too terribly...