### PR TITLE
attach and remove status Indicator depending on what tab is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Status message should appear only in idris projects [#52](https://github.com/idris-hackers/atom-language-idris/issues/52) many thanks to @jeremy-w
+
 ## v0.2.4
 
 ### Added

--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -336,10 +336,15 @@ class IdrisController
         message: warning[3]
 
   attachStatusIndicator: (statusBar) ->
-    @statusIndicator = new StatusIndicator
-    @statusIndicator.initialize()
-    statusBar.addLeftTile
-      item: @statusIndicator
+    if not @statusIndicator
+      @statusIndicator = new StatusIndicator
+      @statusIndicator.initialize()
+      statusBar.addLeftTile
+        item: @statusIndicator
+
+  detachStatusIndicator: ->
+    @statusIndicator?.remove()
+    @statusIndicator = null
 
 
 module.exports = IdrisController

--- a/lib/language-idris.coffee
+++ b/lib/language-idris.coffee
@@ -20,4 +20,11 @@ module.exports =
     this.controller.destroy()
 
   consumeStatusBar: (statusBar) ->
+    subscription = atom.workspace.onDidChangeActivePaneItem (paneItem) =>
+      grammar = paneItem.getGrammar().name
+      if grammar == 'Idris'
+        @controller?.attachStatusIndicator statusBar
+      else
+        @controller?.detachStatusIndicator statusBar
     @controller.attachStatusIndicator statusBar
+    @subscriptions?.add? subscription

--- a/lib/language-idris.coffee
+++ b/lib/language-idris.coffee
@@ -20,11 +20,11 @@ module.exports =
     this.controller.destroy()
 
   consumeStatusBar: (statusBar) ->
-    subscription = atom.workspace.onDidChangeActivePaneItem (paneItem) =>
-      grammar = paneItem.getGrammar().name
-      if grammar == 'Idris'
-        @controller?.attachStatusIndicator statusBar
-      else
-        @controller?.detachStatusIndicator statusBar
-    @controller.attachStatusIndicator statusBar
+    subscription = atom.workspace.observeActivePaneItem (paneItem) =>
+      if paneItem
+        grammar = paneItem.getGrammar().name
+        if grammar == 'Idris'
+          @controller?.attachStatusIndicator statusBar
+        else
+          @controller?.detachStatusIndicator statusBar
     @subscriptions?.add? subscription


### PR DESCRIPTION
attach and remove status Indicator depending on what tab is selected for #52 

## TODO
- attach/remove on the first opened tab. it only works on tab change ATM
- generates an error when clsoing the last tab

## Thanks

@jeremy-w for the pointers