### PR TITLE
parse the new pkgs option in the ipkg file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- parse the new `pkgs`option in the ipkg file [idris-lang/Idris-dev/pull/2668](https://github.com/idris-lang/Idris-dev/pull/2668)
+
 ### Fixed
 
 ## v0.3.1

--- a/documentation/ipkg.md
+++ b/documentation/ipkg.md
@@ -30,8 +30,22 @@ modules = Main
 executable = yourExecutable
 main = Main
 
-opts = "-p lightyear"
+opts = "-p lightyear effects"
 ```
 
 the package will search in the `src`-directory for your files and will
 load the dependencies specified in `opts`.
+
+Newer versions of Idris also accept packages specified in a comma-separated list
+under the `pkgs` key:
+
+```
+package yourProject
+
+sourcedir = src
+modules = Main
+executable = yourExecutable
+main = Main
+
+pkgs = lightyear, effects
+```

--- a/grammars/language-ipkg.cson
+++ b/grammars/language-ipkg.cson
@@ -5,7 +5,7 @@ patterns:
   [
     {
       name: 'keyword.control.ipkg'
-      match: '\\b(package|opts|modules|sourcedir|makefile|objs|executable|main|libs)\\b'
+      match: '\\b(package|opts|modules|sourcedir|makefile|objs|executable|main|libs|pkgs)\\b'
     }
     {
       name: 'string.quoted.double.ipkg'

--- a/lib/idris-ide-mode.coffee
+++ b/lib/idris-ide-mode.coffee
@@ -13,11 +13,22 @@ class IdrisIdeMode extends EventEmitter
   start: (compilerOptions) ->
     if (not @process?) || @process.killed
       pathToIdris = atom.config.get("language-idris.pathToIdris")
-      parameters =
-        if compilerOptions.options
-          ['--ide-mode'].concat compilerOptions.options.split(' ')
+
+      pkgs =
+        if compilerOptions.pkgs.length
+          ["-p"].concat compilerOptions.pkgs
         else
-          ['--ide-mode']
+          []
+
+      options =
+        if compilerOptions.options
+          compilerOptions.options.split(' ')
+        else
+          []
+
+      parameters =
+        ['--ide-mode'].concat pkgs, options
+
       options =
         if compilerOptions.src
           cwd: compilerOptions.src

--- a/lib/utils/ipkg.coffee
+++ b/lib/utils/ipkg.coffee
@@ -4,6 +4,7 @@ Rx = require 'rx-lite'
 
 optionsRegexp = /opts\s*=\s*\"([^\"]*)\"/
 sourcedirRegexp = /sourcedir\s*=\s*([a-zA-Z/0-9.]+)/
+pkgsRegexp = /pkgs\s*=\s*([a-zA-Z/0-9., ]+)/
 
 # Find all ipkg-files in a directory and returns
 # an observable of an array of files
@@ -27,10 +28,17 @@ parseIpkgFile = (fileInfo) ->
   (fileContents) ->
     optionsMatches = fileContents.match optionsRegexp
     sourcedirMatches = fileContents.match sourcedirRegexp
+    pkgsMatches = fileContents.match pkgsRegexp
 
     compilerOptions = { }
     if optionsMatches
       compilerOptions.options = optionsMatches[1]
+
+    compilerOptions.pkgs =
+      if pkgsMatches
+        pkgsMatches[1].split(',').map (s) -> s.trim()
+      else
+        []
 
     compilerOptions.src =
       if sourcedirMatches


### PR DESCRIPTION
deals with the new option as described here: https://github.com/idris-lang/Idris-dev/pull/2668

example `ipkg`-file:
```
package yourProject

sourcedir = src
modules = Main
executable = yourExecutable
main = Main

pkgs = lightyear, effects
```