### PR TITLE
Fix the highlighting of documentation comments

### DIFF
--- a/grammars/language-idris.cson
+++ b/grammars/language-idris.cson
@@ -25,6 +25,11 @@ patterns:
       comment: 'Line comment'
     }
     {
+      name: 'comment.documentation.line.idris'
+      match: '(\\|\\|\\|).*$\n?'
+      comment: 'Line comment'
+    }
+    {
       name: 'storage.type.function.idris'
       match: '\\?[-!#\\$%&\\*\\+\\.\\/<=>@\\\\\^\|~:]+|[-!#\\$%&\\*\\+\\.\\/<=>@\\\\\^\|~:\\?][-!#\\$%&\\*\\+\\.\\/<=>@\\\\\^\|~:]*'
     }
@@ -49,11 +54,6 @@ patterns:
     {
       match: '\\(\\)'
       name: 'constant.unit.idris'
-    }
-    {
-      name: 'comment.documentation.line.idris'
-      match: '(\\|\\|\\|).*$\n?'
-      comment: 'Line comment'
     }
     {
       name: 'comment.block.idris'


### PR DESCRIPTION
Hi! Thanks for fixing line comments highlights! 

Unfortunately documentation comments are still ugly with mainline plugin code: 

![bad](https://cloud.githubusercontent.com/assets/8296326/10676053/42517530-790c-11e5-8761-21c2e5c516f0.png)

I found a way to fix it, but I don't understand it perfectly. I suppose the 
problem is that ```storage.type.function.idris``` shadows 
```comment.documentation.line.idris``` somehow.

So I moved the ```comment.documentation.line.idris``` upper and now it is ok:

![proper](https://cloud.githubusercontent.com/assets/8296326/10676052/424f54d0-790c-11e5-9594-faf94aa957e0.png)

Thanks again for a great work on this plugin!