### PR TITLE
Add implementation/interface keywords

### DIFF
--- a/grammars/language-idris.cson
+++ b/grammars/language-idris.cson
@@ -13,7 +13,7 @@ patterns:
     }
     {
       name: 'keyword.control.idris'
-      match: '\\b(where|with|syntax|proof|postulate|using|namespace|class|instance)\\b'
+      match: '\\b(where|with|syntax|proof|postulate|using|namespace|class|instance|interface|implementation)\\b'
     }
     {
       name: 'keyword.control.idris'


### PR DESCRIPTION
Idris 0.9.20 changed class and instance to interface and implementation. I just added those two to the grammar, but do not know if that is sufficient. At least they get highlighted now.