### PR TITLE
Codecompletion via autocomplete-plus

### DIFF
--- a/grammars/language-idris.cson
+++ b/grammars/language-idris.cson
@@ -17,7 +17,7 @@ patterns:
     }
     {
       name: 'keyword.control.idris'
-      match:  '\\b(public|private|abstract|implicit)\\b'
+      match:  '\\b(public|private|export|implicit)\\b'
     }
     {
       name: 'comment.line.idris'

--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -98,6 +98,9 @@ class IdrisModel
   docsFor: (word) ->
     @prepareCommand [':docs-for', word]
 
+  replCompletions: (word) ->
+      @prepareCommand [':repl-completions', word]
+
   getType: (word) ->
     @prepareCommand [':type-of', word]
 

--- a/lib/language-idris.coffee
+++ b/lib/language-idris.coffee
@@ -9,7 +9,7 @@ module.exports =
       title: 'Idris Location'
       type: 'string'
       default: 'idris'
-      description: 'Location of the Idris executable'
+      description: 'Location of the Idris executable (e.g. /usr/local/bin/idris)'
     panelFontFamily:
       type: 'string'
       default: ''

--- a/lib/language-idris.coffee
+++ b/lib/language-idris.coffee
@@ -43,3 +43,7 @@ module.exports =
   deactivate: ->
     @subscriptions.dispose()
     this.controller.destroy()
+
+  provide: ->
+    console.log "Provider"
+    @controller.provideReplCompletions()

--- a/lib/utils/ipkg.coffee
+++ b/lib/utils/ipkg.coffee
@@ -57,12 +57,15 @@ readIpkgFile = (ipkgFile) ->
 # the compiler options in it.
 compilerOptions = (project) ->
   ipkgFilesObserver = findIpkgFile project
-  ipkgFilesObserver.flatMap (ipkgFiles) ->
-    if ipkgFiles.length
-      ipkgFile = ipkgFiles[0]
-      readIpkgFile(ipkgFile)
-        .map parseIpkgFile(ipkgFile)
-    else
+  ipkgFilesObserver
+    .flatMap (ipkgFiles) ->
+      if ipkgFiles.length
+        ipkgFile = ipkgFiles[0]
+        readIpkgFile(ipkgFile)
+          .map parseIpkgFile(ipkgFile)
+      else
+        Rx.Observable.return { }
+    .catch ->
       Rx.Observable.return { }
 
 module.exports =

--- a/package.json
+++ b/package.json
@@ -31,6 +31,13 @@
       "url": "https://edwinb.wordpress.com/"
     }
   ],
+  "providedServices": {
+    "autocomplete.provider": {
+      "versions": {
+        "2.0.0": "provide"
+      }
+    }
+  },
   "consumedServices": {},
   "dependencies": {
     "atom-message-panel": "^1.2.4",


### PR DESCRIPTION
Please review! Do not merge, yet.
There is a problem with
```
@model.replCompletions prefix
```
in the sense that I need to type check the file once to get an instance of the model. I do not know how to get around that. Otherwise it works very nicely.