### PR TITLE
Fix passing packages in ipkg files

### DIFF
--- a/lib/idris-ide-mode.coffee
+++ b/lib/idris-ide-mode.coffee
@@ -13,10 +13,10 @@ class IdrisIdeMode extends EventEmitter
   start: (compilerOptions) ->
     if (not @process?) || @process.killed
       pathToIdris = atom.config.get("language-idris.pathToIdris")
-
       pkgs =
         if compilerOptions.pkgs && compilerOptions.pkgs.length
-          ["-p"].concat compilerOptions.pkgs
+          p = compilerOptions.pkgs.map (p) -> ["-p", p]
+          [].concat.apply([], p)
         else
           []
 


### PR DESCRIPTION
It should not matter if you pass the packages
through `opts` prefixed with `-p` or through the new `pkgs`.


This:
```
opts = "--warnpartial"

pkgs = effects, lightyear, contrib
```

now results in:
`-p effects -p lightyear -p contrib --warnpartial`

fixes #110