### PR TITLE
use 'cmd' instead of 'alt' on osx

### DIFF
--- a/keymaps/language-idris.json
+++ b/keymaps/language-idris.json
@@ -1,6 +1,5 @@
 {
-  ".platform-win32, atom-text-editor[data-grammar~=\"idris\"],
-   .platform-linux, atom-text-editor[data-grammar~=\"idris\"]": {
+  "atom-text-editor[data-grammar~=\"idris\"]": {
     "ctrl-alt-c": "language-idris:case-split",
     "ctrl-alt-t": "language-idris:type-of",
     "ctrl-alt-a": "language-idris:add-clause",

--- a/keymaps/language-idris.json
+++ b/keymaps/language-idris.json
@@ -1,5 +1,6 @@
 {
-  "atom-text-editor[data-grammar~=\"idris\"]": {
+  ".platform-win32, atom-text-editor[data-grammar~=\"idris\"],
+   .platform-linux, atom-text-editor[data-grammar~=\"idris\"]": {
     "ctrl-alt-c": "language-idris:case-split",
     "ctrl-alt-t": "language-idris:type-of",
     "ctrl-alt-a": "language-idris:add-clause",
@@ -10,5 +11,18 @@
     "ctrl-alt-l": "language-idris:make-lemma",
     "ctrl-alt-r": "language-idris:typecheck",
     "ctrl-alt-m": "language-idris:make-case"
+  },
+
+  ".platform-darwin, atom-text-editor[data-grammar~=\"idris\"]": {
+    "ctrl-cmd-c": "language-idris:case-split",
+    "ctrl-cmd-t": "language-idris:type-of",
+    "ctrl-cmd-a": "language-idris:add-clause",
+    "ctrl-cmd-s": "language-idris:proof-search",
+    "ctrl-cmd-d": "language-idris:docs-for",
+    "ctrl-cmd-enter": "language-idris:open-repl",
+    "ctrl-cmd-w": "language-idris:make-with",
+    "ctrl-cmd-l": "language-idris:make-lemma",
+    "ctrl-cmd-r": "language-idris:typecheck",
+    "ctrl-cmd-m": "language-idris:make-case"
   }
 }


### PR DESCRIPTION
As mentioned in issue #116

I'm not familiar at all with Atom package development, so please let me know if this is not the right way to go about this.