### PR TITLE
Avoid leaking processes, and speed up some calls

### DIFF
--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -114,6 +114,7 @@ class IdrisController
 
   getDocsForWord: ({ target }) =>
     word = Symbol.serializeWord @getWordUnderCursor(target)
+    uri = target.model.getURI()
 
     successHandler = ({ responseType, msg }) =>
       [type, highlightingInfo] = msg
@@ -128,7 +129,9 @@ class IdrisController
       @messages.add informationView
 
     @model
-      .docsFor word
+      .load uri
+      .filter ({ responseType }) -> responseType == 'return'
+      .flatMap => @model.docsFor word
       .subscribe successHandler, @displayErrors
 
   getTypeForWord: ({ target }) =>
@@ -348,6 +351,7 @@ class IdrisController
 
   printDefinition: ({ target }) =>
     word = Symbol.serializeWord @getWordUnderCursor(target)
+    uri = target.model.getURI()
 
     successHandler = ({ responseType, msg }) =>
       [type, highlightingInfo] = msg
@@ -362,7 +366,9 @@ class IdrisController
       @messages.add informationView
 
     @model
-      .printDefinition word
+      .load uri
+      .filter ({ responseType }) -> responseType == 'return'
+      .flatMap => @model.printDefinition word
       .subscribe successHandler, @displayErrors
 
   openREPL: ({ target }) =>

--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -132,6 +132,7 @@ class IdrisController
       .load uri
       .filter ({ responseType }) -> responseType == 'return'
       .flatMap => @model.docsFor word
+      .catch (e) => @model.docsFor word
       .subscribe successHandler, @displayErrors
 
   getTypeForWord: ({ target }) =>
@@ -369,6 +370,7 @@ class IdrisController
       .load uri
       .filter ({ responseType }) -> responseType == 'return'
       .flatMap => @model.printDefinition word
+      .catch (e) => @model.printDefinition word
       .subscribe successHandler, @displayErrors
 
   openREPL: ({ target }) =>

--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -13,7 +13,10 @@ class IdrisModel
   oldCompilerOptions: { }
 
   ideMode: (compilerOptions) ->
-    if !@ideModeRef || !JS.objectEqual(@oldCompilerOptions, compilerOptions)
+    if @ideModeRef && !JS.objectEqual(@oldCompilerOptions, compilerOptions)
+      @ideModeRef.stop()
+      @ideModeRef = null
+    if !@ideModeRef
       @ideModeRef = new IdrisIdeMode
       @ideModeRef.on 'message', @handleCommand
       @ideModeRef.start compilerOptions

--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -14,6 +14,7 @@ class IdrisModel
 
   ideMode: (compilerOptions) ->
     if @ideModeRef && !JS.objectEqual(@oldCompilerOptions, compilerOptions)
+      @ideModeRef.process.removeAllListeners()
       @ideModeRef.stop()
       @ideModeRef = null
     if !@ideModeRef


### PR DESCRIPTION
Here's a workaround I found to #114, split into four commits. It turned out two commands

- Docs For, and
- Print Definition

were using a different set of `compilerOptions` than the others. That in turn would launch a new Idris process whenever the options changed. These commits fix leaking processes and do a "best" effort (i.e. with the smallest patch I could think of) trying to reuse a single set of compiler options.

Reusing the same Idris process has the upside that instead of taking a second or two, the documentation shows up in a fraction of a second (at least for a small source file and when the code compiles).

An alternative I considered but didn't want to invest time in would be to carry around two Idris processes, one with the default options (i.e. empty) to be used when the file fails to load, and another with the last custom options to be used for commands that need loading the current file. That way, we would avoid all but the initial process startup time when working on one file.