### PR TITLE
highlight errors

### DIFF
--- a/styles/highlight.atom-text-editor.less
+++ b/styles/highlight.atom-text-editor.less
@@ -1,0 +1,21 @@
+@import "syntax-variables";
+
+@red-color: @syntax-color-removed;
+
+atom-text-editor::shadow
+{
+  .gutter .line-number
+  {
+    &.highlight-idris-error
+    {
+      background-color: @red-color;
+    }
+  }
+  .line
+  {
+    &.highlight-idris-error
+    {
+      background-color: lighten(@red-color, 20%);
+    }
+  }
+}


### PR DESCRIPTION
this is a successor of #33, since it is no longer active.

in Atom, as far as i know, the only way to draw something on the editor is to use [decoration](https://atom.io/docs/api/v1.10.0/Decoration). and i believe it is quite impossible to show red underlines under the part of the code that's wrong, just like in [idris-mode](https://github.com/idris-hackers/idris-mode) or [vscode-idris](https://github.com/zjhmale/vscode-idris). so a trade-off that highlight the whole line is cool enough i think.

![screenshot](https://cloud.githubusercontent.com/assets/6234553/18299327/6808a8ce-74f2-11e6-967b-959c691fb207.gif)

@melted @david-christiansen @archaeron 