### PR TITLE
Remove that error line is highlighted

### DIFF
--- a/styles/highlight.atom-text-editor.less
+++ b/styles/highlight.atom-text-editor.less
@@ -15,7 +15,6 @@ atom-text-editor::shadow
   {
     &.highlight-idris-error
     {
-      background-color: lighten(@red-color, 20%);
     }
   }
 }


### PR DESCRIPTION
I found that it makes it very hard to read the content of the line
which has the error or to see where the cursor is. This might be
dependend on the Theme used (Material UI)

The red squiggle to mark the line at the line number bar is unaffected.