### PR TITLE
Display an error message from the idris compiler inside a pre block

### DIFF
--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -438,7 +438,7 @@ class IdrisController
       @messages.add new LineMessageView
         line: line
         character: character
-        message: warning[3]
+        preview: warning[3]
         file: uri
 
       editor = atom.workspace.getActiveTextEditor()

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "consumedServices": {},
   "dependencies": {
-    "atom-message-panel": "^1.2.4",
+    "atom-message-panel": "^1.2.7",
     "bennu": "17.3.0",
     "nu-stream": "3.3.1",
     "rx-lite": "4.0.0",


### PR DESCRIPTION
This changes preserves formatting of error messages (line breaks, tabs)
and makes them much easier to read.