### PR TITLE
Grammar : allow incomplete data definition

### DIFF
--- a/grammars/language-idris.cson
+++ b/grammars/language-idris.cson
@@ -151,7 +151,7 @@ patterns:
           name: 'entity.name.type.idris'
         3:
           name: 'keyword.operator.colon.idris'
-      end: '\\b(where)\\b|(=)'
+      end: '\\b(where)\\b|(=)|$'
       endCaptures:
         1:
           name: 'keyword.other.idris'


### PR DESCRIPTION
Idris type checker accepts incomplete data definitions (`data X`) as a hole.