### PR TITLE
Indent after do/where/if/then/else/of

### DIFF
--- a/settings/language-idris.json
+++ b/settings/language-idris.json
@@ -1,7 +1,8 @@
 {
   ".source.idris": {
     "editor": {
-      "commentStart": "-- "
+      "commentStart": "-- ",
+      "increaseIndentPattern": "(((=|\\bdo|\\bwhere|\\bthen|\\belse|\\bof)\\s*)|(\\bif(?!.*\\bthen\\b.*\\belse\\b.*).*))$"
     }
   }
 }


### PR DESCRIPTION
Like language-haskell, indent when starting a newline after a do/where/if.../then/else/of keyword