### PR TITLE
Add support for literate programming lidr files

### DIFF
--- a/grammars/language-idris.cson
+++ b/grammars/language-idris.cson
@@ -1,6 +1,6 @@
 name: 'Idris'
 scopeName: 'source.idris'
-fileTypes: ['idr']
+fileTypes: ['idr', 'lidr']
 patterns:
   [
     {


### PR DESCRIPTION
This support is preliminary. Editing files would probably require a dedicated grammar file, but typechecking and basic commands, such as hole resolution and documentation look up work. Programming tasks such as case splitting and adding definitions, require that the output is corrected afterwards.