### PR TITLE
Fix type inspection

### DIFF
--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -155,6 +155,7 @@ class IdrisController
 
   getTypeForWord: ({ target }) =>
     editor = @getEditor()
+    @saveFile editor
     uri = editor.getURI()
     word = Symbol.serializeWord @getWordUnderCursor(editor)
 


### PR DESCRIPTION
Because the editor was not saved before inspecting types, frequently Error(0) messages were shown, as the editor content and the idris representation would differ.