### PR TITLE
Save editor before executing commands

### DIFF
--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -131,6 +131,7 @@ class IdrisController
 
   getDocsForWord: ({ target }) =>
     editor = @getEditor()
+    @saveFile editor
     uri = editor.getURI()
     word = Symbol.serializeWord @getWordUnderCursor(editor)
 
@@ -370,6 +371,7 @@ class IdrisController
 
   printDefinition: ({ target }) =>
     editor = @getEditor()
+    @saveFile editor
     uri = editor.getURI()
     word = Symbol.serializeWord @getWordUnderCursor(editor)
 


### PR DESCRIPTION
The same reason as #160. And I think `type-of`, `docs-for` and `print-definition` are [pretty similar](https://github.com/zjhmale/vscode-idris/blob/master/src/idris/commands.js#L158-L168), so we should also keep this consistency in this plugin I think 😄 