### PR TITLE
Add Proof Clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,27 @@ A work-in-progress Idris Mode for Atom.
 It supports:
 
  - Typechecking (ctrl-alt-r)
+   - compiles the file and reports errors
  - Case-splitting (ctrl-alt-c)
+   - split a variable which can be pattern matched
  - Clause-adding (ctrl-alt-a)
+   - add a clause to a function
  - Proof-search (ctrl-alt-s)
+   - search for a proof of a hole
  - Showing the types of a variable (ctrl-alt-t)
- - Show the doc for a variable (ctrl-alt-d)
+   - show the type of a hole
+ - Show the doc for a function (ctrl-alt-d)
  - make-with (ctrl-alt-w)
+   - add further variables on the left hand side of a function
  - make-case (ctrl-alt-m)
  - make-lemma (ctrl-alt-l)
+   - lift a hole into a function context
+  - Add proof case
+   - alternate version of clause adding when trying to proof a type. http://docs.idris-lang.org/en/latest/reference/misc.html#match-application
  - Showing holes
  - ipkg highlighting
  - REPL (ctrl-alt-enter)
+ - Apropos view
 
 ## Usage
 

--- a/keymaps/language-idris.json
+++ b/keymaps/language-idris.json
@@ -9,7 +9,8 @@
     "ctrl-alt-w": "language-idris:make-with",
     "ctrl-alt-l": "language-idris:make-lemma",
     "ctrl-alt-r": "language-idris:typecheck",
-    "ctrl-alt-m": "language-idris:make-case"
+    "ctrl-alt-m": "language-idris:make-case",
+    "ctrl-alt-p": "language-idris:add-proof-clause"
   },
 
   ".platform-darwin, atom-text-editor[data-grammar~=\"idris\"]": {
@@ -22,6 +23,7 @@
     "ctrl-cmd-w": "language-idris:make-with",
     "ctrl-cmd-l": "language-idris:make-lemma",
     "ctrl-cmd-r": "language-idris:typecheck",
-    "ctrl-cmd-m": "language-idris:make-case"
+    "ctrl-cmd-m": "language-idris:make-case",
+    "ctrl-cmd-p": "language-idris:add-proof-clause"
   }
 }

--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -127,6 +127,9 @@ class IdrisModel
   addClause: (line, word) ->
     @prepareCommand [':add-clause', line, word]
 
+  addProofClause: (line, word) ->
+    @prepareCommand [':add-proof-clause', line, word]
+
   holes: (width) ->
     @prepareCommand [':metavariables', width]
 


### PR DESCRIPTION
This feature allows the user to add clauses for functions in the style of

```idris
mergeIsCommutative: (x, y: GCounter size) ->
                    x <++> y = y <++> x
([] <++> [] = [] <++> []) <== mergeIsCommutative = Refl

((a :: xs) <++> (b :: ys) = (b :: ys) <++> (a :: xs)) <== mergeIsCommutative =
  rewrite (xs <++> ys = ys <++> xs) <== mergeIsCommutative in
  rewrite (a `maximum` b = b `maximum` a) <== maximumCommutative in
  Refl
```

This feature is outlined at http://docs.idris-lang.org/en/latest/reference/misc.html#match-application

Currently the keyboard shortcut is Ctrl-Alt-p