### PR TITLE
Fixed bug where comments were not highlighted.

### DIFF
--- a/grammars/language-idris.cson
+++ b/grammars/language-idris.cson
@@ -289,7 +289,7 @@ repository:
         name: 'entity.name.function.idris'
       4:
         name: 'keyword.operator.colon.idris'
-    end: "(;|(?<=[^\\s>])\\s*(?!->)\\s*$)"
+    end: "(;|(?=--)|(?<=[^\\s>])\\s*(?!->)\\s*$)"
     patterns:
       [
         {


### PR DESCRIPTION
For example, the `-- blah blah` in the following was not styled as a
comment:

```idris
foo : bar -> bin -- blah blah
```