### PR TITLE
Idris now restarts if stopped and a command is run.

### DIFF
--- a/lib/idris-ide-mode.coffee
+++ b/lib/idris-ide-mode.coffee
@@ -79,7 +79,7 @@ class IdrisIdeMode extends EventEmitter
       atom.notifications.addError short, detail: long
 
   running: ->
-    !!@process
+    !!@process && !@process.killed
 
   stdout: (data) =>
     @buffer += data

--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -13,7 +13,7 @@ class IdrisModel
   oldCompilerOptions: { }
 
   ideMode: (compilerOptions) ->
-    if @ideModeRef && !JS.objectEqual(@oldCompilerOptions, compilerOptions)
+    if @ideModeRef && (!JS.objectEqual(@oldCompilerOptions, compilerOptions) || not @ideModeRef.running())
       @ideModeRef.process.removeAllListeners()
       @ideModeRef.stop()
       @ideModeRef = null


### PR DESCRIPTION
This fixs issue #106.
In short, if the menu item `Packages->Idris->Stop Compiler` is run,
the compiler will stop, but there is currently no way of restarting it.
If a command is run after the compiler is stopped, an error message is
displayed.

Now the Idris process state is inspected before a command is sent to the
process.  If the process is not running it will be restarted before the
command is sent.