### PR TITLE
Various improvements and fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "consumedServices": {},
   "dependencies": {
-    "atom-message-panel": "^1.2.7",
+    "atom-message-panel": "^1.3.0",
     "bennu": "17.3.0",
     "nu-stream": "3.3.1",
     "rx-lite": "4.0.0",


### PR DESCRIPTION
Fixes #154: Display the general idris compiler error message

Use syntax highlighting in the error panel when idris reports source code snippets.

Relates #171: Improve literate idris support: When in literate mode prefix source code inserted by atom with `>` characters where appropriate

Fixes #131: Use syntax highlighting when using the doc command or `:doc` in the REPL.

Update message panel version