### PR TITLE
Copy path of executable to clipboard

### DIFF
--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -64,6 +64,16 @@ class IdrisModel
           when ':warning'
             warning = params[0]
             @warnings[id].push warning
+          when ':run-program'
+            options =
+              detail: "The path for the compiled program. It was copied to your clipboard. Paste it into a terminal to execute."
+              dismissible: true
+              icon: "comment"
+              buttons: [
+                {text: "Confirm"}
+              ]
+            atom.clipboard.write params[0]
+            atom.notifications.addSuccess params[0], options
           when ':set-prompt'
             # Ignore
           else


### PR DESCRIPTION
Relates to #138.
Copy the path of `:exec expr` to the clipboard and present a atom notification.
This solution is not ideal, but I could not find a comint buffer for atom.