### PR TITLE
Add browse command to inspect contents of namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ It supports:
    - lift a hole into a function context
   - Add proof case
    - alternate version of clause adding when trying to proof a type. http://docs.idris-lang.org/en/latest/reference/misc.html#match-application
+ - Browse namespace (ctrl-alt-b)
+   - select the name of a namespace beforehand
  - Showing holes
  - ipkg highlighting
  - REPL (ctrl-alt-enter)

--- a/keymaps/language-idris.json
+++ b/keymaps/language-idris.json
@@ -10,7 +10,8 @@
     "ctrl-alt-l": "language-idris:make-lemma",
     "ctrl-alt-r": "language-idris:typecheck",
     "ctrl-alt-m": "language-idris:make-case",
-    "ctrl-alt-p": "language-idris:add-proof-clause"
+    "ctrl-alt-p": "language-idris:add-proof-clause",
+    "ctrl-alt-b": "language-idris:browse-namespace"
   },
 
   ".platform-darwin, atom-text-editor[data-grammar~=\"idris\"]": {
@@ -24,6 +25,7 @@
     "ctrl-cmd-l": "language-idris:make-lemma",
     "ctrl-cmd-r": "language-idris:typecheck",
     "ctrl-cmd-m": "language-idris:make-case",
-    "ctrl-cmd-p": "language-idris:add-proof-clause"
+    "ctrl-cmd-p": "language-idris:add-proof-clause",
+    "ctrl-cmd-b": "language-idris:browse-namespace"
   }
 }

--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -152,4 +152,7 @@ class IdrisModel
   apropos: (name) ->
     @prepareCommand [':apropos', name]
 
+  browseNamespace: (name) ->
+    @prepareCommand [':browse-namespace', name]
+
 module.exports = IdrisModel


### PR DESCRIPTION
Select the text of a namespace (e.g. Data.Vect) in the editor
and invoke `Language Idris: Browse namespace` or press `Ctrl-Alt-b`
The contents of the namespace are displayed in the message panel.

This is not ideal, but a first step for better namespace browsing support.

This PR fixes issue #86