### PR TITLE
Improve proof search

### DIFF
--- a/lib/idris-controller.coffee
+++ b/lib/idris-controller.coffee
@@ -451,18 +451,22 @@ class IdrisController
       [res] = msg
 
       @hideAndClearMessagePanel()
-
-      editor.transact ->
-        # Move the cursor to the beginning of the word
-        editor.moveToBeginningOfWord()
-        # Because the ? in the Holes isn't part of
-        # the word, we move left once, and then select two
-        # words
-        editor.moveLeft()
-        editor.selectToEndOfWord()
-        editor.selectToEndOfWord()
-        # And then replace the replacement with the guess..
-        editor.insertText res
+      console.log res
+      if (res.startsWith("?"))
+        # proof search returned a new hole
+        @clearMessagePanel 'Idris: Searching proof was not successful.'
+      else
+        editor.transact ->
+          # Move the cursor to the beginning of the word
+          editor.moveToBeginningOfWord()
+          # Because the ? in the Holes isn't part of
+          # the word, we move left once, and then select two
+          # words
+          editor.moveLeft()
+          editor.selectToEndOfWord()
+          editor.selectToEndOfWord()
+          # And then replace the replacement with the guess..
+          editor.insertText res
 
     @model
       .load uri


### PR DESCRIPTION
When the result of the proof search returns an :ok message starting
with a ?, display that the proof search was not succesful, otherwise
insert the found proof.

Fixes #199