### PR TITLE
Consider Elaboration in infix grammar

### DIFF
--- a/grammars/language-idris.cson
+++ b/grammars/language-idris.cson
@@ -106,7 +106,7 @@ patterns:
     }
     {
       name: 'keyword.operator.function.infix.idris'
-      begin: '`'
+      begin: '`(?![\{|\(])'
       beginCaptures:
         0:
           name: 'punctuation.definition.entity.idris'


### PR DESCRIPTION
Infix grammar handles multiline cases like `plus`.
however elaboration scripts know the terms `(x), `{x} and `{{x}}
resulting in unclosed backticks which trip the grammar.
This is an attempt to exclude these special cases in the handling
of infix functions.

Fixes #188
