### PR TITLE
Send notifications during the type check process (:write-string)

### DIFF
--- a/lib/idris-model.coffee
+++ b/lib/idris-model.coffee
@@ -58,6 +58,7 @@ class IdrisModel
             delete @subjects[id]
           when ':write-string'
             msg = params[0]
+            atom.notifications.addInfo msg
             subject.onNext
               responseType: 'write-string'
               msg: msg


### PR DESCRIPTION
Send atom notifications during type checking to inform on the file being checked. 