### PR TITLE
Improve ipkg parser

### DIFF
--- a/lib/utils/ipkg.coffee
+++ b/lib/utils/ipkg.coffee
@@ -4,7 +4,7 @@ Rx = require 'rx-lite'
 
 optionsRegexp = /opts\s*=\s*\"([^\"]*)\"/
 sourcedirRegexp = /sourcedir\s*=\s*([a-zA-Z/0-9.]+)/
-pkgsRegexp = /pkgs\s*=\s*(([a-zA-Z/0-9., ]+\s{0,1})*)/
+pkgsRegexp = /pkgs\s*=\s*(([a-zA-Z/0-9., -_]+\s{0,1})*)/
 
 # Find all ipkg-files in a directory and returns
 # an observable of an array of files


### PR DESCRIPTION
Allow - and _ to be part of the package name in pkgs fields.
Fixes #242