### PR TITLE
Return autocomplete-plus provider from provide function

### DIFF
--- a/lib/language-idris.ts
+++ b/lib/language-idris.ts
@@ -37,6 +37,6 @@ export const deactivate = () => {
 
 export const provide = () => {
     if (controller) {
-        controller.provideReplCompletions()
+        return controller.provideReplCompletions()
     }
 }


### PR DESCRIPTION
I made this change and code completion started working again. It appears the `return` was forgotten during the conversion of the codebase to TypeScript.

![image](https://user-images.githubusercontent.com/7255867/189285287-4b2cfc2e-5194-4c05-b262-0c9ea27514ae.png)
