### PR TITLE
Make make-case and make-with text insertion more robust

### DIFF
--- a/lib/idris-controller.ts
+++ b/lib/idris-controller.ts
@@ -180,14 +180,8 @@ export class IdrisController {
         return atom.workspace.getActiveTextEditor()
     }
 
-    insertNewlineWithoutAutoIndent(): void {
-      const shouldAutoIndent = atom.config.get('editor.autoIndent')
-      try {
-        atom.config.set('editor.autoIndent', false)
-        this.getEditor().insertNewline()
-      } finally {
-        atom.config.set('editor.autoIndent', shouldAutoIndent)
-      }
+    insertNewlineWithoutAutoIndent(editor: TextEditor): void {
+        editor.insertText('\n', { autoIndentNewline: false })
     }
 
     getPane(): Pane {
@@ -496,7 +490,7 @@ export class IdrisController {
                         editor.deleteLine()
                         editor.moveToBeginningOfLine()
                         editor.insertText(clause)
-                        this.insertNewlineWithoutAutoIndent()
+                        this.insertNewlineWithoutAutoIndent(editor)
                         // And move the cursor to the beginning of
                         // the new line
                         editor.moveToBeginningOfLine()
@@ -607,7 +601,7 @@ export class IdrisController {
                         editor.moveToBeginningOfLine()
                         editor.deleteLine()
                         editor.insertText(clause)
-                        this.insertNewlineWithoutAutoIndent()
+                        this.insertNewlineWithoutAutoIndent(editor)
                         // And move the cursor to the beginning of
                         // the new line
                         editor.moveToBeginningOfLine()

--- a/lib/idris-controller.ts
+++ b/lib/idris-controller.ts
@@ -595,10 +595,12 @@ export class IdrisController {
                         editor.moveToBeginningOfLine()
                         editor.deleteLine()
                         editor.insertText(clause)
+                        editor.insertNewline()
+                        editor.deleteToBeginningOfLine()
                         // And move the cursor to the beginning of
                         // the new line
                         editor.moveToBeginningOfLine()
-                        return editor.moveUp()
+                        return editor.moveUp(2)
                     })
                 }
 

--- a/lib/idris-controller.ts
+++ b/lib/idris-controller.ts
@@ -180,6 +180,16 @@ export class IdrisController {
         return atom.workspace.getActiveTextEditor()
     }
 
+    insertNewlineWithoutAutoIndent(): void {
+      const shouldAutoIndent = atom.config.get('editor.autoIndent')
+      try {
+        atom.config.set('editor.autoIndent', false)
+        this.getEditor().insertNewline()
+      } finally {
+        atom.config.set('editor.autoIndent', shouldAutoIndent)
+      }
+    }
+
     getPane(): Pane {
         return atom.workspace.getActivePane()
     }
@@ -481,14 +491,16 @@ export class IdrisController {
 
                     this.hideAndClearMessagePanel()
 
-                    return editor.transact(function () {
+                    return editor.transact(() => {
                         // Delete old line, insert the new with block
                         editor.deleteLine()
+                        editor.moveToBeginningOfLine()
                         editor.insertText(clause)
+                        this.insertNewlineWithoutAutoIndent()
                         // And move the cursor to the beginning of
                         // the new line
                         editor.moveToBeginningOfLine()
-                        return editor.moveUp()
+                        editor.moveUp(2)
                     })
                 }
 
@@ -590,17 +602,16 @@ export class IdrisController {
 
                     this.hideAndClearMessagePanel()
 
-                    return editor.transact(function () {
+                    return editor.transact(() => {
                         // Delete old line, insert the new case block
                         editor.moveToBeginningOfLine()
                         editor.deleteLine()
                         editor.insertText(clause)
-                        editor.insertNewline()
-                        editor.deleteToBeginningOfLine()
+                        this.insertNewlineWithoutAutoIndent()
                         // And move the cursor to the beginning of
                         // the new line
                         editor.moveToBeginningOfLine()
-                        return editor.moveUp(2)
+                        editor.moveUp(2)
                     })
                 }
 


### PR DESCRIPTION
I've changed the text replacement functions to make sure they insert text at the beginning of the line and add a newline at the end. Also, I've tried to make sure that auto-indentation doesn't mess the text we insert.