### PR TITLE
Remove stdout handler before killing process

### DIFF
--- a/lib/idris-ide-mode.ts
+++ b/lib/idris-ide-mode.ts
@@ -68,6 +68,8 @@ export class IdrisIdeMode extends EventEmitter {
     }
 
     stop() {
+        this.process?.removeAllListeners()
+        this.process?.stdout.removeAllListeners()
         return this.process != null ? this.process.kill() : undefined
     }
 

--- a/lib/idris-model.ts
+++ b/lib/idris-model.ts
@@ -25,7 +25,6 @@ export class IdrisModel {
             (!JS.objectEqual(this.oldCompilerOptions, compilerOptions) ||
                 !this.ideModeRef.running())
         ) {
-            this.ideModeRef.process?.removeAllListeners()
             this.ideModeRef.stop()
             this.ideModeRef = null
         }

--- a/spec/idris-ide-mode-spec.coffee
+++ b/spec/idris-ide-mode-spec.coffee
@@ -1,0 +1,17 @@
+{ IdrisIdeMode } = require "../lib/idris-ide-mode"
+child_process = require "child_process"
+{ EventEmitter } = require "events"
+
+describe "Idris IDE mode", ->
+  it "should not crash after ending the Idris process", ->
+    mockProcess = new EventEmitter()
+    mockProcess.stdout = new EventEmitter()
+    mockProcess.stdout.setEncoding = -> mockProcess.stdout
+    mockProcess.kill = ->
+      # Idris prints this when it's killed
+      # .emit calls the listeners synchronously
+      mockProcess.stdout.emit('data', 'Alas the file is done, aborting')
+    mockedSpawn = spyOn(child_process, 'spawn').andReturn mockProcess
+    ideMode = new IdrisIdeMode()
+    ideMode.start({ pkgs: [] })
+    ideMode.stop()


### PR DESCRIPTION
On switching between two project folders, the Idris process is killed. Idris prints something like "The file is closed" to stdout before terminating. At least on Windows, we will capture that and then fail to parse it as an SExp.