### PR TITLE
Add WSL Idris installation compatibility

### DIFF
--- a/lib/idris-controller.ts
+++ b/lib/idris-controller.ts
@@ -18,10 +18,11 @@ import {
     Pane,
     WorkspaceOpenOptions,
 } from 'atom'
+import { windowsToWsl } from 'wsl-path'
 
 export class IdrisController {
     errorMarkers: Array<DisplayMarker> = []
-    model: IdrisModel = new IdrisModel()
+    model: IdrisModel = new IdrisModel(windowsToWsl)
     messages: MessagePanelView = new MessagePanelView({
         title: 'Idris Messages',
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -292,6 +292,11 @@
       "requires": {
         "underscore": "^1.9.1"
       }
+    },
+    "wsl-path": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/wsl-path/-/wsl-path-3.0.4.tgz",
+      "integrity": "sha512-HWlboAWRgn+qoUfvYxfr2I1PcF5FAY3PQIwSOPisAIP1JjHKsC5L2SrnGxQBCTuSmR9QwZWo8Q5pRczERTaUIg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,12 @@
             "type": "boolean",
             "default": false,
             "description": "Enable ligatures in the various idris panels"
+        },
+        "idrisInWsl": {
+            "title": "Integrate with an Idris installation in WSL",
+            "type": "boolean",
+            "default": false,
+            "description": "Enable this if you installed Idris in WSL but run the editor in Windows"
         }
     },
     "providedServices": {
@@ -84,7 +90,8 @@
         "preact": "10.4.4",
         "rx-lite": "4.0.8",
         "tslib": "1.11.1",
-        "typescript": "3.9.2"
+        "typescript": "3.9.2",
+        "wsl-path": "^3.0.1"
     },
     "devDependencies": {
         "@types/atom": "1.40.4",

--- a/spec/idris-model-spec.coffee
+++ b/spec/idris-model-spec.coffee
@@ -1,0 +1,30 @@
+{ IdrisModel } = require "../lib/idris-model"
+Rx = require "rx-lite"
+
+describe "Idris model", ->
+  it "should use Linux paths to change directory when WSL integration is enabled", ->
+    finished = false
+    spyOn(atom.config, "get").andReturn true
+    idrisModel = new IdrisModel(-> Promise.resolve("/wsl/path"))
+    interpretSpy = spyOn(idrisModel, "interpret").andReturn Rx.Observable.of(null)
+    runs ->
+      idrisModel.changeDirectory("C:\\windows\\path").subscribe ->
+        finished = true
+    waitsFor (-> finished), "changeDirectory should complete", 500
+    runs ->
+      expect(interpretSpy).toHaveBeenCalledWith(":cd /wsl/path")
+
+  it "should use Linux paths to load file when WSL integration is enabled", ->
+    finished = false
+    spyOn(atom.config, "get").andReturn true
+    idrisModel = new IdrisModel(-> Promise.resolve("/wsl/path"))
+    prepareCommandSpy = spyOn(idrisModel, "prepareCommand").andReturn Rx.Observable.of(null)
+    runs ->
+      idrisModel.load("C:\\windows\\path").subscribe ->
+        finished = true
+    waitsFor (-> finished), "load should complete", 500
+    runs ->
+      expect(prepareCommandSpy).toHaveBeenCalledWith({
+        type: "load-file"
+        fileName: "/wsl/path"
+      })


### PR DESCRIPTION
The use case for this PR is that I have Idris installed through Pack in WSL. (I've considered installing Idris in Windows, but Pack doesn't support Windows.) Since Idris in Linux won't understand Widows paths, something needs to translate them. [VS Code has a more advanced solution](https://code.visualstudio.com/docs/remote/wsl) to this kind of problem, but Atom and Pulsar don't.

So I'm making this PR but I figure it might warrant more discussion since:
- I'm adding a dependency, [wsl-path](https://www.npmjs.com/package/wsl-path), which is a wrapper around the wslpath tool installed in WSL distros. We could access the tool directly, but I don't think I knew it existed before I found the npm package.
- More importantly, maybe someone thinks that translating paths is outside the purview of atom-language-idris and should be dealt with some other way